### PR TITLE
Remove default team for codesigning

### DIFF
--- a/Lulu.xcodeproj/project.pbxproj
+++ b/Lulu.xcodeproj/project.pbxproj
@@ -540,7 +540,6 @@
 				TargetAttributes = {
 					3DC986F81DB5DCD20022A2ED = {
 						CreatedOnToolsVersion = 8.0;
-						DevelopmentTeam = JU7A7G4PUR;
 						ProvisioningStyle = Automatic;
 						SystemCapabilities = {
 							com.apple.Keychain = {
@@ -1139,7 +1138,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_ENTITLEMENTS = Lulu/Lulu.entitlements;
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
-				DEVELOPMENT_TEAM = JU7A7G4PUR;
+				DEVELOPMENT_TEAM = "";
 				INFOPLIST_FILE = Lulu/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = com.teamlulu.Lulu;
@@ -1157,7 +1156,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_ENTITLEMENTS = Lulu/Lulu.entitlements;
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
-				DEVELOPMENT_TEAM = JU7A7G4PUR;
+				DEVELOPMENT_TEAM = "";
 				INFOPLIST_FILE = Lulu/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = com.teamlulu.Lulu;


### PR DESCRIPTION
- Set signing team to None

This prevents defaulting to a non-existent team, Patrick's dev account